### PR TITLE
added new line after when exiting temp monitoring

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -65,6 +65,6 @@ func runMonitorTempCmd(ps *services.PrinterService) util.RunFunc {
 		// wait for keyboard input to kill thread
 		fmt.Scanf("%s")
 		quit <- true
-		fmt.Print(SHOW_CURSOR)
+		fmt.Print("\n\n", SHOW_CURSOR)
 	}
 }


### PR DESCRIPTION
by adding new line when exiting temp monitoring you avoid overwriting the last line of monitoring